### PR TITLE
CRAN: follow upstream doc

### DIFF
--- a/CRAN/deb.zh.md
+++ b/CRAN/deb.zh.md
@@ -19,9 +19,10 @@ deb {{endpoint}}/bin/linux/{{os}} {{release}}-{{version}}/
 
 <tmpl z-lang="bash">
 # Debian 用户添加该公钥
-{{sudo}}apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'
+gpg --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'
+gpg --armor --export '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' | {{sudo}} tee /etc/apt/trusted.gpg.d/cran_debian_key.asc
 # Ubuntu 用户添加该公钥
-{{sudo}}apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+wget -qO- {{endpoint}}/bin/linux/ubuntu/marutter_pubkey.asc | {{sudo}} tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
 {{sudo}}apt-get update
 {{sudo}}apt-get install r-base-dev
 </tmpl>

--- a/CRAN/deb.zh.md
+++ b/CRAN/deb.zh.md
@@ -23,6 +23,7 @@ gpg --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2D
 gpg --armor --export '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' | {{sudo}} tee /etc/apt/trusted.gpg.d/cran_debian_key.asc
 # Ubuntu 用户添加该公钥
 wget -qO- {{endpoint}}/bin/linux/ubuntu/marutter_pubkey.asc | {{sudo}} tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+# 更新软件包
 {{sudo}}apt-get update
 {{sudo}}apt-get install r-base-dev
 </tmpl>


### PR DESCRIPTION
修改镜像站CRAN帮助中关于添加GPG公钥的内容 tuna/issues#1413

文档: [debian](https://cloud.r-project.org/bin/linux/debian/)、[ubuntu](https://cloud.r-project.org/bin/linux/ubuntu/)

（上游debian和ubuntu写的key的添加方式就不一样，我也没在镜像站中找到debian的公钥文件