### PR TITLE
Update LXC documents

### DIFF
--- a/lxc-images/lxc-images.zh.md
+++ b/lxc-images/lxc-images.zh.md
@@ -10,6 +10,7 @@
 * LXC/LXD 继续沿用之前体系，并且只能使用 Canonical 公司的镜像库。**LXC/LXD 不能使用本镜像库**。如果强行让 LXC/LXD 使用本镜像库，有些镜像可能可以启动，但是会出现各种各样的兼容性问题，例如虚拟机镜像无法启动 agent，无法进行 "exec"。
 
 参考来源：
+
 * https://discuss.linuxcontainers.org/t/important-notice-for-lxd-users-image-server/18479
 * https://discuss.linuxcontainers.org/t/lxd-is-no-longer-part-of-the-linux-containers-project/17593
 

--- a/lxc-images/lxc-images.zh.md
+++ b/lxc-images/lxc-images.zh.md
@@ -7,7 +7,7 @@
 经过 LXD/Incus 项目分叉后，目前差异如下：
 
 * Incus 有自己独立的命令行工具和守护进程（incus/incusd），并且只使用 incus 命令交互，不再暴露 incusd 命令给使用者。**本镜像库（linuxcontainers 镜像）只能用于 Incus 项目**。
-* LXC/LXD 继续沿用之前体系，并且只能使用 Canonical 公司的镜像库。**LXC/LXD 不能使用本镜像库**。如果强行让 LXC/LXD 使用本镜像库，有些镜像可能可以启动，但是会出现各种各样的兼容性问题，例如虚拟机镜像无法启动 agent，无法进行 "exec"
+* LXC/LXD 继续沿用之前体系，并且只能使用 Canonical 公司的镜像库。**LXC/LXD 不能使用本镜像库**。如果强行让 LXC/LXD 使用本镜像库，有些镜像可能可以启动，但是会出现各种各样的兼容性问题，例如虚拟机镜像无法启动 agent，无法进行 "exec"。
 
 参考来源：
 * https://discuss.linuxcontainers.org/t/important-notice-for-lxd-users-image-server/18479

--- a/lxc-images/lxc-images.zh.md
+++ b/lxc-images/lxc-images.zh.md
@@ -11,6 +11,7 @@
 
 参考来源：
 
+
 * https://discuss.linuxcontainers.org/t/important-notice-for-lxd-users-image-server/18479
 * https://discuss.linuxcontainers.org/t/lxd-is-no-longer-part-of-the-linux-containers-project/17593
 

--- a/lxc-images/lxc-images.zh.md
+++ b/lxc-images/lxc-images.zh.md
@@ -11,7 +11,6 @@
 
 参考来源：
 
-
 * https://discuss.linuxcontainers.org/t/important-notice-for-lxd-users-image-server/18479
 * https://discuss.linuxcontainers.org/t/lxd-is-no-longer-part-of-the-linux-containers-project/17593
 

--- a/lxc-images/lxc-images.zh.md
+++ b/lxc-images/lxc-images.zh.md
@@ -1,19 +1,19 @@
-# LXD/Incus 分叉说明
+## LXD/Incus 分叉说明
 
-**此镜像库为 linuxcontainers 的镜像，只适用于 Incus 项目**
+**此镜像库为 linuxcontainers 的镜像，只适用于 Incus 项目。**
 
 曾经 LXD 是 linuxcontainers 社区维护的项目，LXC 是命令行工具，LXD 是后台守护进程。
 后来 Canonical 公司接管了 LXD 项目进行开发维护，linuxcontainers 社区分叉并独立维护了 Incus 项目作为 LXC 和 LXD 的替代。
 经过 LXD/Incus 项目分叉后，目前差异如下：
 
-* Incus 有自己独立的命令行工具和守护进程（incus/incusd），并且只使用 incus 命令交互，不再暴露 incusd 命令给使用者。linuxcontainers 的镜像库（也就是本镜像库）**只能用于 Incus 项目**。
-* LXC/LXD 继续沿用之前体系，并且只能使用 Canonical 公司的镜像库，**不能使用本镜像库**。如果强行让 LXC/LXD 使用本镜像库，有些镜像可能可以启动，但是会出现各种各样的兼容性问题，例如虚拟机镜像无法启动 agent，无法进行 "exec"
+* Incus 有自己独立的命令行工具和守护进程（incus/incusd），并且只使用 incus 命令交互，不再暴露 incusd 命令给使用者。**本镜像库（linuxcontainers 镜像）只能用于 Incus 项目**。
+* LXC/LXD 继续沿用之前体系，并且只能使用 Canonical 公司的镜像库。**LXC/LXD 不能使用本镜像库**。如果强行让 LXC/LXD 使用本镜像库，有些镜像可能可以启动，但是会出现各种各样的兼容性问题，例如虚拟机镜像无法启动 agent，无法进行 "exec"
 
 参考来源：
 * https://discuss.linuxcontainers.org/t/important-notice-for-lxd-users-image-server/18479
 * https://discuss.linuxcontainers.org/t/lxd-is-no-longer-part-of-the-linux-containers-project/17593
 
-# Incus 使用镜像加速的方法
+## Incus 使用镜像加速的方法
 
 创建一个 remote 链接，指向镜像站即可，或替换掉默认的 images 链接。
 

--- a/lxc-images/lxc-images.zh.md
+++ b/lxc-images/lxc-images.zh.md
@@ -1,17 +1,23 @@
-LXC 1.0 以上版本增加了 `download` 模版，支持下载定义好的系统镜像。
+# LXD/Incus 分叉说明
 
-欲使用镜像站进行下载加速，可以在 `lxc-create -t download` 的选项部分，
-增加 `--server` 即可，例如：
+**此镜像库为 linuxcontainers 的镜像，只适用于 Incus 项目**
 
-<tmpl z-lang="bash">
-lxc-create -t download -n my-container -- --server {{host}}{{path}}
-</tmpl>
+曾经 LXD 是 linuxcontainers 社区维护的项目，LXC 是命令行工具，LXD 是后台守护进程。
+后来 Canonical 公司接管了 LXD 项目进行开发维护，linuxcontainers 社区分叉并独立维护了 Incus 项目作为 LXC 和 LXD 的替代。
+经过 LXD/Incus 项目分叉后，目前差异如下：
 
-**LXD/LXC 2.0 及以上版本使用镜像加速的方法**:
+* Incus 有自己独立的命令行工具和守护进程（incus/incusd），并且只使用 incus 命令交互，不再暴露 incusd 命令给使用者。linuxcontainers 的镜像库（也就是本镜像库）**只能用于 Incus 项目**。
+* LXC/LXD 继续沿用之前体系，并且只能使用 Canonical 公司的镜像库，**不能使用本镜像库**。如果强行让 LXC/LXD 使用本镜像库，有些镜像可能可以启动，但是会出现各种各样的兼容性问题，例如虚拟机镜像无法启动 agent，无法进行 "exec"
+
+参考来源：
+* https://discuss.linuxcontainers.org/t/important-notice-for-lxd-users-image-server/18479
+* https://discuss.linuxcontainers.org/t/lxd-is-no-longer-part-of-the-linux-containers-project/17593
+
+# Incus 使用镜像加速的方法
 
 创建一个 remote 链接，指向镜像站即可，或替换掉默认的 images 链接。
 
 <tmpl z-lang="bash">
-lxc remote add mirror-images {{endpoint}}/ --protocol=simplestreams --public
-lxc image list mirror-images:
+incus remote add mirror-images {{endpoint}}/ --protocol=simplestreams --public
+incus image list mirror-images:
 </tmpl>


### PR DESCRIPTION
背景： https://github.com/tuna/issues/issues/2004


原文中提及的 “LXC 1.0” 是 2016 年前的产物，我认为没必要继续保留了，现在大家应该都在用 LXC >= 2.0 （2016年后）的新命令参数了  ( LXC 2.0.0 release announcement https://linuxcontainers.org/lxc/news/2016_04_06_00_00.html  )