### PR TITLE
update mirror guide for postmarketOS (and alpine's pmos section)

### DIFF
--- a/alpine/pmos.zh.md
+++ b/alpine/pmos.zh.md
@@ -3,14 +3,7 @@
 本节供 [postmarketOS 帮助](../postmarketOS/)使用。
 
 <tmpl z-lang="bash">
-pmbootstrap --mirror-pmOS=http://mirror/postmarketOS/ --mirror-alpine={{endpoint}}/ init
-pmbootstrap --mirror-pmOS=http://mirror/postmarketOS/ --mirror-alpine={{endpoint}}/ install
-</tmpl>
-
-将 `/etc/apk/repositories` 替换为以下的内容
-
-<tmpl z-path="/etc/apk/repositories">
-http://mirror/postmarketOS/master
-{{endpoint}}/edge/main
-{{endpoint}}/edge/community
+pmbootstrap config mirrors.alpine https://mirrors.tuna.tsinghua.edu.cn/alpine/
+pmbootstrap config mirrors.pmaports https://mirrors.tuna.tsinghua.edu.cn/postmarketOS/
+pmbootstrap config mirrors.systemd https://mirrors.tuna.tsinghua.edu.cn/postmarketOS/extra-repos/systemd/
 </tmpl>

--- a/alpine/pmos.zh.md
+++ b/alpine/pmos.zh.md
@@ -3,7 +3,7 @@
 本节供 [postmarketOS 帮助](../postmarketOS/)使用。
 
 <tmpl z-lang="bash">
-pmbootstrap config mirrors.alpine https://mirrors.tuna.tsinghua.edu.cn/alpine/
-pmbootstrap config mirrors.pmaports https://mirrors.tuna.tsinghua.edu.cn/postmarketOS/
-pmbootstrap config mirrors.systemd https://mirrors.tuna.tsinghua.edu.cn/postmarketOS/extra-repos/systemd/
+pmbootstrap config mirrors.alpine {{endpoint}}/alpine/
+pmbootstrap config mirrors.pmaports {{endpoint}}/postmarketOS/
+pmbootstrap config mirrors.systemd {{endpoint}}/postmarketOS/extra-repos/systemd/
 </tmpl>

--- a/postmarketOS/postmarketOS.zh.md
+++ b/postmarketOS/postmarketOS.zh.md
@@ -1,24 +1,20 @@
 ### pmbootstrap
 
-需要在每个 `pmbootstrap` 命令中都指定镜像
+通过`pmbootstrap config`更新镜像配置。
 
 <tmpl z-lang="bash">
-pmbootstrap --mirror-pmOS={{endpoint}}/ --mirror-alpine=http://mirror/alpine/ init
-pmbootstrap --mirror-pmOS={{endpoint}}/ --mirror-alpine=http://mirror/alpine/ install
+pmbootstrap config mirrors.alpine https://mirrors.tuna.tsinghua.edu.cn/alpine/
+pmbootstrap config mirrors.pmaports https://mirrors.tuna.tsinghua.edu.cn/postmarketOS/
+pmbootstrap config mirrors.systemd https://mirrors.tuna.tsinghua.edu.cn/postmarketOS/extra-repos/systemd/
 </tmpl>
 
 其中 `mirror-alpine` 部分需要前往 [Alpine 帮助](../alpine/)构造。
 
-### 安装后的 postmarketOS
+### 移除镜像配置
 
-将 `/etc/apk/repositories` 替换为以下的内容
-
-<tmpl>
-{{endpoint}}/master
-http://mirror/alpine/edge/main
-http://mirror/alpine/edge/community
+<tmpl z-lang="bash">
+pmbootstrap config -r mirrors.alpine
+pmbootstrap config -r mirrors.pmaports
+pmbootstrap config -r mirrors.systemd
 </tmpl>
 
-其中 alpine 部分需要前往 [Alpine 帮助](../alpine/)构造。
-
-可以按照需要使用不同的 channel，例如 `postmarketOS/v21.12`，`alpine/v3.15/main`

--- a/postmarketOS/postmarketOS.zh.md
+++ b/postmarketOS/postmarketOS.zh.md
@@ -3,9 +3,9 @@
 通过`pmbootstrap config`更新镜像配置。
 
 <tmpl z-lang="bash">
-pmbootstrap config mirrors.alpine https://mirrors.tuna.tsinghua.edu.cn/alpine/
-pmbootstrap config mirrors.pmaports https://mirrors.tuna.tsinghua.edu.cn/postmarketOS/
-pmbootstrap config mirrors.systemd https://mirrors.tuna.tsinghua.edu.cn/postmarketOS/extra-repos/systemd/
+pmbootstrap config mirrors.alpine {{endpoint}}/alpine/
+pmbootstrap config mirrors.pmaports {{endpoint}}/postmarketOS/
+pmbootstrap config mirrors.systemd {{endpoint}}/postmarketOS/extra-repos/systemd/
 </tmpl>
 
 其中 `mirror-alpine` 部分需要前往 [Alpine 帮助](../alpine/)构造。

--- a/postmarketOS/postmarketOS.zh.md
+++ b/postmarketOS/postmarketOS.zh.md
@@ -1,6 +1,6 @@
 ### pmbootstrap
 
-通过`pmbootstrap config`更新镜像配置。
+通过 `pmbootstrap config` 更新镜像配置。
 
 <tmpl z-lang="bash">
 pmbootstrap config mirrors.alpine {{endpoint}}/alpine/


### PR DESCRIPTION
Update commands for postmarketOS according to https://docs.postmarketos.org/pmbootstrap/mirrors.html .
Alpine's postmarketOS section is also updated.