### PR TITLE
recommend juliaup instead of jill

### DIFF
--- a/julia-releases/julia-releases.zh.md
+++ b/julia-releases/julia-releases.zh.md
@@ -10,20 +10,20 @@ Julia 是一个全新的以科学计算为核心的通用编程语言，其二�
 
 尽管一些包管理工具（例如 `apt`, `pacman`, `conda`, `choco`) 中提供有 Julia，但是这些工具或多或少都存在一些由二进制 依赖导致的问题，因此官方推荐的方式是根据自己的使用平台下载相应的二进制程序，然后通过解压的方式进行手动安装。
 
-## Julia 一键安装
+## juliaup 使用说明
 
-对于习惯命令行的用户而言，[jill.py](https://github.com/johnnychen94/jill.py) 是一个社区维护的全平台下一键安装 Julia 的命令行工具。
+[juliaup](https://github.com/JuliaLang/juliaup) 是现在 Julia 社区默认推荐的安装方式，通过设置环境变量 `JULIAUP_SERVER` 的地址为 `{{endpoint}}` 后，即可正常使用镜像站来下载 Julia 程序。
 
-安装/更新 `jill`： `pip install jill --user -U` (需要 Python `3.6` 或更新的版本)
+以下是 juliaup 官方的标准安装方式
 
-* 安装 Julia：`jill install [VERSION] [--upstream UPSTREAM] [--confirm]`
-  * `jill install`：最新的 `x.y.z` 版本
-  * `jill install --confirm`：无需交互确认直接安装
-  * `jill install --upstream BFSU`：从北外镜像下载并安装
-  * `jill install 1.4`：安装最新的 `1.4.z` 版本
-* 查询现存的上游镜像：`jill upstream`
-* 帮助文档：`jill [COMMAND] --help`
-  * `jill --help`：查询存在的 `jill` 命令
-  * `jill install --help`：查询 `install` 命令的使用方式
+Windows：
 
-利用 `jill` 安装完成后即可通过在命令行执行 `julia`/`julia-1`/`julia-1.4` 来启动不同版本的 Julia.
+```powershell
+winget install --name Julia --id 9NJNWW8PVKMN -e -s msstore
+```
+
+Mac, Linux, and FreeBSD：
+
+```shell
+curl -fsSL https://install.julialang.org | sh
+```


### PR DESCRIPTION
I'm the author of [jill.py](https://github.com/johnnychen94/jill.py), which was written back in the days juliaup didn't exist yet.
But now since the Julia community has embraced the juliaup project, let's do the switch and gradually sunset jill.py, thus I deleted the part about jill and only left the juliaup stuff.