### PR TITLE
Update Ubuntu version options, add 26.04 LTS

### DIFF
--- a/ubuntu/zh.yaml
+++ b/ubuntu/zh.yaml
@@ -7,8 +7,6 @@ input:
   release:
     _: Ubuntu 版本
     option:
-      resolute:
-        _: Ubuntu 26.04 LTS
       questing:
         _: Ubuntu 25.10
       noble:
@@ -18,8 +16,6 @@ input:
   release_deb822:
     _: Ubuntu 版本
     option:
-      resolute:
-        _: Ubuntu 26.04 LTS
       questing:
         _: Ubuntu 25.10
       noble:

--- a/ubuntu/zh.yaml
+++ b/ubuntu/zh.yaml
@@ -7,19 +7,23 @@ input:
   release:
     _: Ubuntu 版本
     option:
-      noble:
-        _: Ubuntu 24.04 LTS
+      resolute:
+        _: Ubuntu 26.04 LTS
       questing:
         _: Ubuntu 25.10
+      noble:
+        _: Ubuntu 24.04 LTS
       jammy:
         _: Ubuntu 22.04 LTS
   release_deb822:
     _: Ubuntu 版本
     option:
-      noble:
-        _: Ubuntu 24.04 LTS
+      resolute:
+        _: Ubuntu 26.04 LTS
       questing:
         _: Ubuntu 25.10
+      noble:
+        _: Ubuntu 24.04 LTS
       jammy:
         _: Ubuntu 22.04 LTS
   src:


### PR DESCRIPTION
Add an option for Ubuntu 26.04 LTS (resolute) in ubuntu/zh.yaml.