### PR TITLE
omv: add 8.0 (synchrony) to release option

### DIFF
--- a/OpenMediaVault/zh.yaml
+++ b/OpenMediaVault/zh.yaml
@@ -5,6 +5,8 @@ input:
   release:
     _: 版本
     option:
+      synchrony:
+        _: 8.0 (synchrony)
       sandworm:
         _: 7.0 (sandworm)
       shaitan:


### PR DESCRIPTION
add openmediavault synchrony. closes https://github.com/tuna/issues/issues/2497