### PR TITLE
pypi: Remove the trailing slash in uv.toml

### DIFF
--- a/pypi/pypi.zh.md
+++ b/pypi/pypi.zh.md
@@ -81,7 +81,7 @@ poetry config experimental.new-installer false
 
 ```{ztmpl lang="toml"}
 [[index]]
-url = "{{endpoint}}/web/simple/"
+url = "{{endpoint}}/web/simple"
 default = true
 ```
 


### PR DESCRIPTION
It works either way, but https://docs.astral.sh/uv/concepts/configuration-files does not have the trailing slash.

If there are multiple contributors to the same repo, and one contributor adds the slash while another one does not, then conflicts may occur when modifying `uv.lock`. Therefore, it is best to align with the official documentation.

Relates-to: https://github.com/astral-sh/uv/issues/6349