### PR TITLE
adobe-fonts: correct an oversight and update the status of typst

### DIFF
--- a/adobe-fonts/source-han-sans.zh.md
+++ b/adobe-fonts/source-han-sans.zh.md
@@ -109,7 +109,7 @@
    - **可变**——笔画可从粗到细任意连续调节
    - **静态**——最多只有七种字重可选
 
-   可变（variable）版本更灵活，文件总体积也更小（例如 OTF SC 版覆盖七种字重，可变版本只需单个 ~50 MB 文件，而静态版本需要七个 ~20 MB 文件）；但它依赖 2016 年发布的 OpenType 可变字体技术，某些平台尚不兼容（例如[很多办公软件和视频编辑软件不完全支持](https://v-fonts.com/support/)，TeX 引擎中[只有 LuaTeX 支持](https://github.com/latex3/fontspec/blob/70970a5/fontspec-doc-featset.tex#L686)而 [XeTeX 尚不支持](https://sourceforge.net/p/xetex/feature-requests/28/)，[Typst 导出 SVG 时目前只能加载最细字重](https://github.com/typst/typst/issues/185)）。
+   可变（variable）版本更灵活，文件总体积也更小（例如 OTF SC 版覆盖七种字重，可变版本只需单个 ~30 MB 文件，而静态版本需要七个 ~16 MB 文件）；但它依赖 2016 年发布的 OpenType 可变字体技术，某些平台尚不兼容（例如[很多办公软件和视频编辑软件不完全支持](https://v-fonts.com/support/)，TeX 引擎中[只有 LuaTeX 支持](https://github.com/latex3/fontspec/blob/70970a5/fontspec-doc-featset.tex#L686)而 [XeTeX 尚不支持](https://sourceforge.net/p/xetex/feature-requests/28/)，[Typst 早于 v0.15.0-rc.1 (2026-06-10) 的版本亦不支持](https://github.com/typst/typst/issues/185)）。
 
    静态版本的字重包括 ExtraLight—0, Light—160, Normal—320, Regular—390 ([一说 420](https://github.com/adobe-fonts/source-han-sans/issues/600)), Medium—560, Bold—780, Heavy—1000，其中最常用的是 Regular 和 Bold。每种字重可以单独下载，只下载部分字重亦可使用。中间五种字重采用[多母版技术](https://glyphsapp.com/zh/learn/multiple-masters-part-1-setting-up-masters)从最细与最粗字重插值而来，这里所标数值即插值系数；最终发行字体中的[字重标称数值](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass)则是 50 的整倍数，与此并不相同，详见 [designspace 源文件](https://github.com/adobe-fonts/source-han-sans/blob/master/Masters/designspaces/SourceHanSansSC-VF.designspace)。
 


### PR DESCRIPTION
- [**typst 最新版本**支持可变字体了](https://typst.app/docs/changelog/0.15.0/)；现在更新了页面上相关表述。

- 黑体部分解释可变字体总体积更小时，列举了**具体数值**，但之前这些数值错写成宋体的了；现在**改正为黑体的**。

  这一规律对宋体、黑体都适用，但黑体笔画细节比宋体少，所以文件整体会更小，数值明显不同。

  当时 #45 我私下最早把宋体放前面，所以统计的是宋体；后来我颠倒了顺序（因为黑体比宋体早，而且按字典序 Sans < Serif），然后想当然以为宋体、黑体差不了多少，就没重新统计……

另外[据说](https://github.com/typst/typst/issues/8434) HarfBuzz（偏底层的文本整形引擎）用思源字体的`*.ttf`会触发 65536 溢出，而`*.otf`不会。考虑到目前页面上只提供`*.otf`链接，而且该问题的波及范围不甚清楚，就不往上写了。如果以后有人想加`*.ttf`链接，可能需要注意一下。
